### PR TITLE
Fix duplicate group file messages for sender

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -768,6 +768,7 @@ async function loadGroups() {
     }
 
     if (data.type === 'group-file' && data.groupName === currentGroup) {
+      if (data.from === myNick) return; // игнорируем собственные файлы
       console.log('Получен файл от:', data.from, data.name);
       receiveFile(data);
     }
@@ -920,6 +921,7 @@ async function loadGroups() {
           groupName: currentGroup,
           ...payload
         }));
+        receiveFile({ from: myNick, ...payload });
       } else if (currentPeer) {
         ws.send(JSON.stringify({
           type: "file",


### PR DESCRIPTION
## Summary
- Ignore `group-file` events from the current user to prevent duplicate display
- Render group files locally upon sending so upload is shown immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa187ce848333966d120a52b6b1ef